### PR TITLE
Add ``None`` type to support polls that do not require a response.

### DIFF
--- a/docs/ureport-api.rst
+++ b/docs/ureport-api.rst
@@ -192,9 +192,14 @@ API methods
    * ``numeric`` (``n`` in RapidSMS polls)
    * ``registration`` (``r`` in RapidSMS polls)
    * ``location`` (``l`` in RapidSMS polls)
+   * ``none`` (see below)
    * ``other`` (all other RapidSMS polls)
 
    Updates to this API may extend the list of allowed ``type`` values.
+
+   Polls of type ``none`` require no response from the user and responses
+   to such polls should not be submitted to UReport. These polls are
+   informational messages (and are typically used during registration).
 
    Allowed values for ``response_type``:
 

--- a/docs/ureport-api.rst
+++ b/docs/ureport-api.rst
@@ -169,6 +169,8 @@ API methods
      further details.
    * ``start_date``: The date and time on which the poll began (or will begin).
    * ``end_date``: The date and time on which the poll ended (or will end).
+   * ``is_registration``: ``true`` for polls that are part of
+     registration, ``false`` otherwise.
    * ``type``: The data type of responses to the question. See below for
      the possible values.
    * ``default_response``: The ``default_response`` is the default text to
@@ -190,7 +192,6 @@ API methods
 
    * ``text`` (``t`` in RapidSMS polls)
    * ``numeric`` (``n`` in RapidSMS polls)
-   * ``registration`` (``r`` in RapidSMS polls)
    * ``location`` (``l`` in RapidSMS polls)
    * ``none`` (see below)
    * ``other`` (all other RapidSMS polls)
@@ -244,6 +245,7 @@ API methods
           "question_voice": "http://www.example.com/poll1234.ogg",
           "start_date": "2012-04-23T18:25:43.511Z",
           "end_date": null,
+          "is_registration": false,
           "type": "text",
           "default_response": null,
           "default_response_voice": null,


### PR DESCRIPTION
These are mostly needed during registration, but could be useful whenever an informational message needs to be sent.
