### PR TITLE
Add U-Report API component

### DIFF
--- a/paths.js
+++ b/paths.js
@@ -1,4 +1,5 @@
 module.exports = [
     'src/index.js',
+    'src/api.js',
     'src/app.js'
 ];

--- a/src/api.js
+++ b/src/api.js
@@ -2,20 +2,20 @@ vumi_ureport.api = function() {
     var vumigo = require('vumigo_v02');
     var utils = vumigo.utils;
     var Extendable = utils.Extendable;
+
     var JsonApi = vumigo.http_api.JsonApi;
+    var HttpResponseError = vumigo.http_api.HttpResponseError;
 
     var UReportApi = Extendable.extend(function(self, im, base_url, opts) {
         self.http = JsonApi.call(self, im, opts);
         self.base_url = base_url;
 
         self.url = function(paths) {
-            return [self.base_url]
-                .concat(paths)
-                .join('/');
+            return [self.base_url, paths].join('/');
         };
 
         self.ureporters = function(backend, user_addr) {
-            return new UReportApi();
+            return new UReportersApi(self, backend, user_addr);
         };
     });
 
@@ -24,26 +24,29 @@ vumi_ureport.api = function() {
         self.backend = backend;
         self.user_addr = user_addr;
 
-        self.url = function(paths) {
-            return self.api.url([
-                'ureporters',
-                self.backend,
-                self.user_addr
-            ].concat(paths));
+        self.url = function(path) {
+            return self.api.url(['ureporters', path].join('/'));
         };
 
         self.get = function() {
-            return self.api.http.get(self.url());
+            return self
+                .api.http.get(self.url())
+                .get('user')
+                .catch(catch_code(404, null));
         };
 
         self.polls = {};
 
         self.polls.current = function() {
-            return self.api.http.get(self.url(['polls', 'current']));
+            return self
+                .api.http.get(self.url('polls/current'))
+                .get('poll');
         };
 
         self.polls.topics = function() {
-            return self.api.http.get(self.url(['polls', 'topics']));
+            return self
+                .api.http.get(self.url('polls/topics'))
+                .get('poll_topics');
         };
 
         self.poll = function(id) {
@@ -52,9 +55,11 @@ vumi_ureport.api = function() {
 
         self.reports = {};
         self.reports.submit = function(report) {
-            return self.api.http.post(self.url(['reports/']), {
-                data: {report: report}
-            });
+            return self
+                .api.http.post(self.url('reports/'), {
+                    data: {report: report}
+                })
+                .get('result');
         };
     });
 
@@ -67,21 +72,38 @@ vumi_ureport.api = function() {
             return self.ureporter.url([
                 'poll',
                 self.id
-            ].concat(paths));
+            ].join('/'));
         };
 
         self.responses = {};
 
         self.responses.submit = function(response) {
-            return self.api.http.post(self.url(['responses/']), {
-                data: {response: response}
-            });
+            return self
+                .api.http.post(self.url('responses/'), {
+                    data: {response: response}
+                })
+                .get('result');
         };
 
         self.summary = function() {
-            return self.api.http.get(self.url(['summary']));
+            return self
+                .api.http.get(self.url('summary'))
+                .get('poll_result');
         };
     });
+
+    function catch_code(code, result) {
+        return function(e) {
+            var match = e instanceof HttpResponseError
+                     && e.reponse.code === code;
+
+            if (!match) {
+                throw e;
+            }
+
+            return utils.maybe_call(result);
+        };
+    }
 
     return {
         UReportApi: UReportApi,

--- a/src/api.js
+++ b/src/api.js
@@ -1,0 +1,91 @@
+vumi_ureport.api = function() {
+    var vumigo = require('vumigo_v02');
+    var utils = vumigo.utils;
+    var Extendable = utils.Extendable;
+    var JsonApi = vumigo.http_api.JsonApi;
+
+    var UReportApi = Extendable.extend(function(self, im, base_url, opts) {
+        self.http = JsonApi.call(self, im, opts);
+        self.base_url = base_url;
+
+        self.url = function(paths) {
+            return [self.base_url]
+                .concat(paths)
+                .join('/');
+        };
+
+        self.ureporters = function(backend, user_addr) {
+            return new UReportApi();
+        };
+    });
+
+    var UReportersApi = Extendable.extend(function(self, api, backend, user_addr) {
+        self.api = api;
+        self.backend = backend;
+        self.user_addr = user_addr;
+
+        self.url = function(paths) {
+            return self.api.url([
+                'ureporters',
+                self.backend,
+                self.user_addr
+            ].concat(paths));
+        };
+
+        self.get = function() {
+            return self.api.http.get(self.url());
+        };
+
+        self.polls = {};
+
+        self.polls.current = function() {
+            return self.api.http.get(self.url(['polls', 'current']));
+        };
+
+        self.polls.topics = function() {
+            return self.api.http.get(self.url(['polls', 'topics']));
+        };
+
+        self.poll = function(id) {
+            return new PollApi(self, id);
+        };
+
+        self.reports = {};
+        self.reports.submit = function(report) {
+            return self.api.http.post(self.url(['reports/']), {
+                data: {report: report}
+            });
+        };
+    });
+
+    var PollApi = Extendable.extend(function(self, ureporter, id) {
+        self.id = id;
+        self.api = ureporter.api;
+        self.ureporter = ureporter;
+
+        self.url = function(paths) {
+            return self.ureporter.url([
+                'poll',
+                self.id
+            ].concat(paths));
+        };
+
+        self.responses = {};
+
+        self.responses.submit = function(response) {
+            return self.api.http.post(self.url(['responses/']), {
+                data: {response: response}
+            });
+        };
+
+        self.summary = function() {
+            return self.api.http.get(self.url(['summary']));
+        };
+    });
+
+    return {
+        UReportApi: UReportApi,
+        UReportersApi: UReportersApi,
+        PollApi: PollApi
+    };
+}();

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -9,31 +9,346 @@ var UReportApi = vumi_ureport.api.UReportApi;
 
 describe("api", function() {
     describe("UReportApi", function() {
+        var ureport;
+
+        function add_fixture(opts) {
+            opts.request = utils.set_defaults(opts.request || {}, {
+                content_type: 'application/json; charset=utf-8'
+            });
+
+            opts.response = utils.set_defaults(opts.response || {}, {
+                code: 200
+            });
+
+            if ('data' in opts.request) {
+                opts.request.body = JSON.stringify(opts.request.data);
+            }
+
+            if ('data' in opts.response) {
+                opts.response.body = JSON.stringify(opts.response.data);
+            }
+
+            ureport.im.api.add_http_fixture(opts);
+        }
+
+        function get_request() {
+            var request = ureport.im.api.http_requests[0];
+
+            if (request.body) {
+                request.data = JSON.parse(request.body);
+            }
+
+            return request;
+        }
+
+        beforeEach(function() {
+            return test_utils.make_im().then(function(im) {
+                ureport = new UReportApi(
+                    im,
+                    'http://example.com',
+                    'vumi_go_sms');
+            });
+        });
+
         describe(".ureporters.get", function() {
-            it("should return the ureporter's data");
-            it("should return null if no ureporter is found");
+            it("should return the ureporter's data", function() {
+                add_fixture({
+                    request: {
+                        method: 'GET',
+                        url: [
+                            'http://example.com',
+                            'ureporters/vumi_go_sms/+256775551122'
+                        ].join('/')
+                    },
+                    response: {
+                        data: {
+                            success: true,
+                            user: {
+                                registered: true,
+                                language: 'sw'
+                            }
+                        }
+                    }
+                });
+
+                return ureport
+                    .ureporters('+256775551122')
+                    .get()
+                    .then(function(user) {
+                        assert.deepEqual(user, {
+                            registered: true,
+                            language: 'sw'
+                        });
+                    });
+            });
+        });
+
+        describe(".ureporters.is_registered", function() {
+            it("should return true if the ureporter is registered",
+            function() {
+                add_fixture({
+                    request: {
+                        method: 'GET',
+                        url: [
+                            'http://example.com',
+                            'ureporters/vumi_go_sms/+256775551122'
+                        ].join('/')
+                    },
+                    response: {
+                        data: {
+                            success: true,
+                            user: {
+                                registered: true,
+                                language: 'sw'
+                            }
+                        }
+                    }
+                });
+
+                return ureport
+                    .ureporters('+256775551122')
+                    .is_registered()
+                    .then(function(registered) {
+                        assert(registered);
+                    });
+            });
+
+            it("should return false if the ureporter is not registered",
+            function() {
+                add_fixture({
+                    request: {
+                        method: 'GET',
+                        url: [
+                            'http://example.com',
+                            'ureporters/vumi_go_sms/+256775551122'
+                        ].join('/')
+                    },
+                    response: {
+                        data: {
+                            success: true,
+                            user: {
+                                registered: false,
+                                language: 'sw'
+                            }
+                        }
+                    }
+                });
+
+                return ureport
+                    .ureporters('+256775551122')
+                    .is_registered()
+                    .then(function(registered) {
+                        assert(!registered);
+                    });
+            });
+
+            it("should return false if the ureporter is not found",
+            function() {
+                add_fixture({
+                    request: {
+                        method: 'GET',
+                        url: [
+                            'http://example.com',
+                            'ureporters/vumi_go_sms/+256775551122'
+                        ].join('/')
+                    },
+                    response: {code: 404}
+                });
+
+                return ureport
+                    .ureporters('+256775551122')
+                    .is_registered()
+                    .then(function(registered) {
+                        assert(!registered);
+                    });
+            });
         });
 
         describe(".ureporters.polls.current", function() {
-            it("should the return current poll");
+            it("should the return current poll", function() {
+                add_fixture({
+                    request: {
+                        method: 'GET',
+                        url: [
+                            'http://example.com',
+                            'ureporters/vumi_go_sms/+256775551122',
+                            'polls/current'
+                        ].join('/')
+                    },
+                    response: {
+                        data: {
+                            success: true,
+                            poll: {id: '1234'}
+                        }
+                    }
+                });
+
+                return ureport
+                    .ureporters('+256775551122')
+                    .polls.current()
+                    .then(function(poll) {
+                        assert.deepEqual(poll, {id: '1234'});
+                    });
+            });
         });
 
         describe(".ureporters.polls.topics", function() {
-            it("should the return current topics");
+            it("should the return current topics", function() {
+                add_fixture({
+                    request: {
+                        method: 'GET',
+                        url: [
+                            'http://example.com',
+                            'ureporters/vumi_go_sms/+256775551122',
+                            'polls/topics'
+                        ].join('/')
+                    },
+                    response: {
+                        data: {
+                            success: true,
+                            poll_topics: [{poll_id: "poll-1234"}]
+                        }
+                    }
+                });
+
+                return ureport
+                    .ureporters('+256775551122')
+                    .polls.topics()
+                    .then(function(topics) {
+                        assert.deepEqual(topics, [{poll_id: "poll-1234"}]);
+                    });
+            });
         });
 
         describe(".ureporters.poll.responses.submit", function() {
-            it("should submit a poll response");
-            it("should return the submission result");
+            beforeEach(function() {
+                add_fixture({
+                    request: {
+                        method: 'POST',
+                        url: [
+                            'http://example.com',
+                            'ureporters/vumi_go_sms/+256775551122',
+                            'poll/1234/responses/'
+                        ].join('/'),
+                        data: {response: 'response text'}
+                    },
+                    response: {
+                        data: {
+                            success: true,
+                            result: {
+                                accepted: true,
+                                response: "Thank you for answering the poll."
+                            }
+                        }
+                    }
+                });
+            });
+
+            it("should submit a poll response", function() {
+                return ureport
+                    .ureporters('+256775551122')
+                    .poll('1234')
+                    .responses.submit('response text')
+                    .then(function() {
+                        var request = get_request();
+
+                        assert.deepEqual(
+                            request.data,
+                            {response: 'response text'});
+                    });
+            });
+
+            it("should return the submission result", function() {
+                return ureport
+                    .ureporters('+256775551122')
+                    .poll('1234')
+                    .responses.submit('response text')
+                    .then(function(result) {
+                        assert.deepEqual(result, {
+                            accepted: true,
+                            response: "Thank you for answering the poll."
+                        });
+                    });
+            });
         });
 
         describe(".ureporters.poll.summary", function() {
-            it("should return the poll summary");
+            it("should return the poll summary", function() {
+                add_fixture({
+                    request: {
+                        method: 'GET',
+                        url: [
+                            'http://example.com',
+                            'ureporters/vumi_go_sms/+256775551122',
+                            'poll/1234/summary'
+                        ].join('/')
+                    },
+                    response: {
+                        data: {
+                            success: true,
+                            poll_result: {total_responses: 3756}
+                        }
+                    }
+                });
+
+                return ureport
+                    .ureporters('+256775551122')
+                    .poll('1234')
+                    .summary()
+                    .then(function(summary) {
+                        assert.deepEqual(summary, {total_responses: 3756});
+                    });
+            });
         });
 
         describe(".ureporters.reports.submit", function() {
-            it("should submit a report");
-            it("should return the submission result");
+            beforeEach(function() {
+                add_fixture({
+                    request: {
+                        method: 'POST',
+                        url: [
+                            'http://example.com',
+                            'ureporters/vumi_go_sms/+256775551122',
+                            'reports/'
+                        ].join('/'),
+                        data: {report: 'report text'}
+                    },
+                    response: {
+                        data: {
+                            success: true,
+                            result: {
+                                accepted: true,
+                                response: "Thank you for your report."
+                            }
+                        }
+                    }
+                });
+            });
+
+            it("should submit a report", function() {
+                return ureport
+                    .ureporters('+256775551122')
+                    .reports.submit('report text')
+                    .then(function() {
+                        var request = get_request();
+
+                        assert.deepEqual(
+                            request.data,
+                            {report: 'report text'});
+                    });
+            });
+
+            it("should return the submission result", function() {
+                return ureport
+                    .ureporters('+256775551122')
+                    .reports.submit('report text')
+                    .then(function(result) {
+                        assert.deepEqual(result, {
+                            accepted: true,
+                            response: "Thank you for your report."
+                        });
+                    });
+            });
         });
     });
 });

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,0 +1,39 @@
+var assert = require("assert");
+
+var vumigo = require('vumigo_v02');
+var test_utils = vumigo.test_utils;
+var utils = vumigo.utils;
+
+var UReportApi = vumi_ureport.api.UReportApi;
+
+
+describe("api", function() {
+    describe("UReportApi", function() {
+        describe(".ureporters.get", function() {
+            it("should return the ureporter's data");
+            it("should return null if no ureporter is found");
+        });
+
+        describe(".ureporters.polls.current", function() {
+            it("should the return current poll");
+        });
+
+        describe(".ureporters.polls.topics", function() {
+            it("should the return current topics");
+        });
+
+        describe(".ureporters.poll.responses.submit", function() {
+            it("should submit a poll response");
+            it("should return the submission result");
+        });
+
+        describe(".ureporters.poll.summary", function() {
+            it("should return the poll summary");
+        });
+
+        describe(".ureporters.reports.submit", function() {
+            it("should submit a report");
+            it("should return the submission result");
+        });
+    });
+});


### PR DESCRIPTION
This component will do the talking to the U-Report API, abstracting away the actual http calls from the sandbox app. It will also allow us to swap out the component for a dummy to make the app's tests easier to read and write.
