### PR TITLE
Change UReportApi to handle polls with null ids

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -56,22 +56,21 @@ vumi_ureport.api = function() {
             return poll_b;
         };
 
-        self.polls.current = function(options) {
-            options = _(options || {}).defaults({
-                nones: {
-                    limit: 1,
-                    use: false,
-                    concat: false
-                }
+        self.polls.current = function(opts) {
+            opts = _(opts || {}).defaults({nones: {}});
+            _(opts.nones).defaults({
+                limit: 1,
+                use: false,
+                concat: false
             });
 
-            var n = options.nones.limit;
+            var n = opts.nones.limit;
             var nones = [];
 
             function next() {
                 return self.polls._current().then(function(poll) {
-                    if (!n-- || poll.type !== 'none' || options.nones.use) {
-                        return options.nones.concat
+                    if (!(n--) || poll.type !== 'none' || opts.nones.use) {
+                        return opts.nones.concat
                             ? nones.concat([poll]).reduce(self.polls._concat)
                             : poll;
                     }

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -131,7 +131,11 @@ describe("api", function() {
                     response: {
                         data: {
                             success: true,
-                            poll: {id: '1234'}
+                            poll: {
+                                id: '1234',
+                                type: 'text',
+                                question: 'What is your name?'
+                            }
                         }
                     }
                 });
@@ -140,8 +144,199 @@ describe("api", function() {
                     .ureporters('+256775551122')
                     .polls.current()
                     .then(function(poll) {
-                        assert.deepEqual(poll, {id: '1234'});
+                        assert.deepEqual(poll, {
+                            id: '1234',
+                            type: 'text',
+                            question: 'What is your name?'
+                        });
                     });
+            });
+
+            describe("if a none poll is given back", function() {
+                it("should get the next poll until the given limit is hit",
+                function() {
+                    api.http.fixtures.add({
+                        request: {
+                            method: 'GET',
+                            url: [
+                                'http://example.com',
+                                'ureporters/vumi_go_sms/+256775551122',
+                                'polls/current'
+                            ].join('/')
+                        },
+                        responses: [{
+                            data: {
+                                success: true,
+                                poll: {
+                                    id: null,
+                                    type: 'none',
+                                    question: 'Hello!'
+                                }
+                            }
+                        }, {
+                            data: {
+                                success: true,
+                                poll: {
+                                    id: null,
+                                    type: 'none',
+                                    question: 'Welcome!'
+                                }
+                            }
+                        }, {
+                            data: {
+                                success: true,
+                                poll: {
+                                    id: '1234',
+                                    type: 'text',
+                                    question: 'What is your name?'
+                                }
+                            }
+                        }]
+                    });
+
+                    return ureport
+                        .ureporters('+256775551122')
+                        .polls.current({nones: {limit: 2}})
+                        .then(function(poll) {
+                            assert.deepEqual(poll, {
+                                id: '1234',
+                                type: 'text',
+                                question: 'What is your name?'
+                            });
+                        });
+                });
+
+                it("should not get the next poll if asked to use nones",
+                function() {
+                    api.http.fixtures.add({
+                        request: {
+                            method: 'GET',
+                            url: [
+                                'http://example.com',
+                                'ureporters/vumi_go_sms/+256775551122',
+                                'polls/current'
+                            ].join('/')
+                        },
+                        responses: [{
+                            data: {
+                                success: true,
+                                poll: {
+                                    id: null,
+                                    type: 'none',
+                                    question: 'Hello!'
+                                }
+                            }
+                        }, {
+                            data: {
+                                success: true,
+                                poll: {
+                                    id: '1234',
+                                    type: 'text',
+                                    question: 'What is your name?'
+                                }
+                            }
+                        }]
+                    });
+
+                    return ureport
+                        .ureporters('+256775551122')
+                        .polls.current({nones: {use: true}})
+                        .then(function(poll) {
+                            assert.deepEqual(poll, {
+                                id: null,
+                                type: 'none',
+                                question: 'Hello!'
+                            });
+                        });
+                });
+
+                it("should get the next poll until a non-none poll is given",
+                function() {
+                    api.http.fixtures.add({
+                        request: {
+                            method: 'GET',
+                            url: [
+                                'http://example.com',
+                                'ureporters/vumi_go_sms/+256775551122',
+                                'polls/current'
+                            ].join('/')
+                        },
+                        responses: [{
+                            data: {
+                                success: true,
+                                poll: {
+                                    id: null,
+                                    type: 'none',
+                                    question: 'Hello!'
+                                }
+                            }
+                        }, {
+                            data: {
+                                success: true,
+                                poll: {
+                                    id: '1234',
+                                    type: 'text',
+                                    question: 'What is your name?'
+                                }
+                            }
+                        }]
+                    });
+
+                    return ureport
+                        .ureporters('+256775551122')
+                        .polls.current({nones: {limit: 10}})
+                        .then(function(poll) {
+                            assert.deepEqual(poll, {
+                                id: '1234',
+                                type: 'text',
+                                question: 'What is your name?'
+                            });
+                        });
+                });
+
+                it("should concat the non-polls to the actual poll if asked",
+                function() {
+                    api.http.fixtures.add({
+                        request: {
+                            method: 'GET',
+                            url: [
+                                'http://example.com',
+                                'ureporters/vumi_go_sms/+256775551122',
+                                'polls/current'
+                            ].join('/')
+                        },
+                        responses: [{
+                            data: {
+                                success: true,
+                                poll: {
+                                    id: null,
+                                    type: 'none',
+                                    question: 'Hello!'
+                                }
+                            }
+                        }, {
+                            data: {
+                                success: true,
+                                poll: {
+                                    id: '1234',
+                                    type: 'text',
+                                    question: 'What is your name?'
+                                }
+                            }
+                        }]
+                    });
+
+                    return ureport
+                        .ureporters('+256775551122')
+                        .polls.current({nones: {concat: true}})
+                        .then(function(poll) {
+                            assert.deepEqual(poll, {
+                                id: '1234',
+                                type: 'text',
+                                question: 'Hello! What is your name?'
+                            });
+                        });
+                });
             });
         });
 

--- a/vumi-ureport.demo.js
+++ b/vumi-ureport.demo.js
@@ -1,6 +1,8 @@
 var vumi_ureport = {};
 
 vumi_ureport.api = function() {
+    var _ = require('underscore');
+
     var vumigo = require('vumigo_v02');
     var utils = vumigo.utils;
     var Extendable = utils.Extendable;
@@ -44,11 +46,44 @@ vumi_ureport.api = function() {
 
         self.polls = {};
 
-        self.polls.current = function() {
+        self.polls._current = function() {
             return self
                 .api.http.get(self.url('polls/current'))
                 .get('data')
                 .get('poll');
+        };
+
+        self.polls._concat = function(poll_a, poll_b) {
+            poll_b.question = [poll_a.question, poll_b.question].join(' ');
+            return poll_b;
+        };
+
+        self.polls.current = function(opts) {
+            opts = _(opts || {}).defaults({nones: {}});
+            _(opts.nones).defaults({
+                limit: 1,
+                use: false,
+                concat: false
+            });
+
+            var n = opts.nones.limit;
+            var nones = [];
+
+            function next() {
+                return self.polls._current().then(function(poll) {
+                    if (!(n--) || poll.type !== 'none' || opts.nones.use) {
+                        return opts.nones.concat
+                            ? nones.concat([poll]).reduce(self.polls._concat)
+                            : poll;
+                    }
+                    else {
+                        nones.push(poll);
+                        return next();
+                    }
+                });
+            }
+
+            return next();
         };
 
         self.polls.topics = function() {

--- a/vumi-ureport.js
+++ b/vumi-ureport.js
@@ -1,6 +1,8 @@
 var vumi_ureport = {};
 
 vumi_ureport.api = function() {
+    var _ = require('underscore');
+
     var vumigo = require('vumigo_v02');
     var utils = vumigo.utils;
     var Extendable = utils.Extendable;
@@ -44,11 +46,44 @@ vumi_ureport.api = function() {
 
         self.polls = {};
 
-        self.polls.current = function() {
+        self.polls._current = function() {
             return self
                 .api.http.get(self.url('polls/current'))
                 .get('data')
                 .get('poll');
+        };
+
+        self.polls._concat = function(poll_a, poll_b) {
+            poll_b.question = [poll_a.question, poll_b.question].join(' ');
+            return poll_b;
+        };
+
+        self.polls.current = function(opts) {
+            opts = _(opts || {}).defaults({nones: {}});
+            _(opts.nones).defaults({
+                limit: 1,
+                use: false,
+                concat: false
+            });
+
+            var n = opts.nones.limit;
+            var nones = [];
+
+            function next() {
+                return self.polls._current().then(function(poll) {
+                    if (!(n--) || poll.type !== 'none' || opts.nones.use) {
+                        return opts.nones.concat
+                            ? nones.concat([poll]).reduce(self.polls._concat)
+                            : poll;
+                    }
+                    else {
+                        nones.push(poll);
+                        return next();
+                    }
+                });
+            }
+
+            return next();
         };
 
         self.polls.topics = function() {


### PR DESCRIPTION
The plan is to hold onto the first registration poll with a null id, to allow the possibility of concatenating it to the second registration poll holding the first question.
