### PR TITLE
Handle empty topic sets

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -203,6 +203,10 @@ vumi_ureport.app = function() {
         // TODO what to put as default question?
         self.states.add('states:results:choose', function(name) {
             return self.ureporter.polls.topics().then(function(topics) {
+                if (!topics.length) {
+                    return self.states.create('states:results:empty');
+                }
+
                 return new ChoiceState(name, {
                     question: "Choose poll:",
                     choices: topics.map(function(topic) {
@@ -215,6 +219,16 @@ vumi_ureport.app = function() {
                         };
                     }
                 });
+            });
+        });
+
+        // TODO what to put as text
+        self.states.add('states:results:empty', function(name) {
+            return new EndState(name, {
+                text: [
+                    "There are no polls to see results at the moment,",
+                    "please try again later."].join(' '),
+                next: 'states:start'
             });
         });
 

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -209,19 +209,46 @@ describe("app", function() {
             });
 
             describe("if the user chooses to view the results", function() {
-                it("should show the user the current poll topics", function() {
-                    return tester
-                        .setup.user.state('states:main_menu')
-                        .input('2')
-                        .check.reply([
-                            "Choose poll:",
-                            "1. Poll 1",
-                            "2. Poll 2"
-                        ].join('\n'))
-                        .check.user.state('states:results:choose')
-                        .run();
+                describe("if there are poll topics", function() {
+                    it("should show the user the current topics", function() {
+                        return tester
+                            .setup.user.state('states:main_menu')
+                            .input('2')
+                            .check.reply([
+                                "Choose poll:",
+                                "1. Poll 1",
+                                "2. Poll 2"
+                            ].join('\n'))
+                            .check.user.state('states:results:choose')
+                            .run();
+                    });
+                });
+
+                describe("if there are no poll topics", function() {
+                    it("should tell the user there are no topics", function() {
+                        return tester
+                            .setup.user.state('states:main_menu')
+                            .setup.user.addr('user_on_empty_topics')
+                            .input('2')
+                            .check.reply([
+                                "There are no polls to see results at",
+                                "the moment, please try again later."
+                            ].join(' '))
+                            .check.user.state('states:results:empty')
+                            .run();
+                    });
                 });
             });
+
+        describe("when the user is told there are no topics", function() {
+            it("should start at the beginning on the next session", function() {
+                return tester
+                    .setup.user.state('states:results:empty')
+                    .start()
+                    .check.user.state('states:main_menu')
+                    .run();
+            });
+        });
 
             describe("if the user chooses to submit a report", function() {
                 it("should ask the user to enter their report", function() {

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -698,6 +698,19 @@ module.exports = function() {
     },
     {
         "request": {
+            "method": "GET",
+            "url": "http://example.com/ureporters/vumi_go_test/user_on_empty_topics/polls/topics"
+        },
+        "response": {
+            "code": 200,
+            "data": {
+                "success": true,
+                "poll_topics": []
+            }
+        }
+    },
+    {
+        "request": {
             "method": "POST",
             "url": "http://example.com/ureporters/vumi_go_test/user_default/reports",
             "data": {

--- a/vumi-ureport.demo.js
+++ b/vumi-ureport.demo.js
@@ -367,6 +367,10 @@ vumi_ureport.app = function() {
         // TODO what to put as default question?
         self.states.add('states:results:choose', function(name) {
             return self.ureporter.polls.topics().then(function(topics) {
+                if (!topics.length) {
+                    return self.states.create('states:results:empty');
+                }
+
                 return new ChoiceState(name, {
                     question: "Choose poll:",
                     choices: topics.map(function(topic) {
@@ -379,6 +383,16 @@ vumi_ureport.app = function() {
                         };
                     }
                 });
+            });
+        });
+
+        // TODO what to put as text
+        self.states.add('states:results:empty', function(name) {
+            return new EndState(name, {
+                text: [
+                    "There are no polls to see results at the moment,",
+                    "please try again later."].join(' '),
+                next: 'states:start'
             });
         });
 

--- a/vumi-ureport.js
+++ b/vumi-ureport.js
@@ -367,6 +367,10 @@ vumi_ureport.app = function() {
         // TODO what to put as default question?
         self.states.add('states:results:choose', function(name) {
             return self.ureporter.polls.topics().then(function(topics) {
+                if (!topics.length) {
+                    return self.states.create('states:results:empty');
+                }
+
                 return new ChoiceState(name, {
                     question: "Choose poll:",
                     choices: topics.map(function(topic) {
@@ -379,6 +383,16 @@ vumi_ureport.app = function() {
                         };
                     }
                 });
+            });
+        });
+
+        // TODO what to put as text
+        self.states.add('states:results:empty', function(name) {
+            return new EndState(name, {
+                text: [
+                    "There are no polls to see results at the moment,",
+                    "please try again later."].join(' '),
+                next: 'states:start'
             });
         });
 


### PR DESCRIPTION
We should let the user know that there are no topics if the api gives us an empty topic set.
