### PR TITLE
Handle null poll api responses

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -58,6 +58,10 @@ vumi_ureport.app = function() {
             var error = "Response rejected, please try again.";
 
             return self.ureporter.polls.current().then(function(poll) {
+                if (poll === null) {
+                    return self.states.create('states:register:none');
+                }
+
                 return new FreeText(name, {
                     question: poll.question,
 
@@ -103,6 +107,10 @@ vumi_ureport.app = function() {
             var response;
 
             return self.ureporter.polls.current().then(function(poll) {
+                if (poll === null) {
+                    return self.states.create('states:poll:none');
+                }
+
                 return new FreeText(name, {
                     question: poll.question,
 
@@ -129,6 +137,15 @@ vumi_ureport.app = function() {
                         };
                     }
                 });
+            });
+        });
+
+        self.states.add('states:poll:none', function(name) {
+            return new EndState(name, {
+                text: [
+                    "There is currently no poll available,",
+                    "please try again later"].join(' '),
+                next: 'states:start'
             });
         });
 

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -152,6 +152,74 @@ describe("api", function() {
                     });
             });
 
+            describe("if null is given back", function() {
+                it("should use the none polls if available", function() {
+                    api.http.fixtures.add({
+                        request: {
+                            method: 'GET',
+                            url: [
+                                'http://example.com',
+                                'ureporters/vumi_go_sms/+256775551122',
+                                'polls/current'
+                            ].join('/')
+                        },
+                        responses: [{
+                            data: {
+                                success: true,
+                                poll: {
+                                    id: null,
+                                    type: 'none',
+                                    question: 'Hello!'
+                                }
+                            }
+                        }, {
+                            data: {
+                                success: true,
+                                poll: null
+                            }
+                        }]
+                    });
+
+                    return ureport
+                        .ureporters('+256775551122')
+                        .polls.current()
+                        .then(function(poll) {
+                            assert.deepEqual(poll, {
+                                id: null,
+                                type: 'none',
+                                question: 'Hello!'
+                            });
+                        });
+                });
+
+                it("should return null if no none polls are available",
+                function() {
+                    api.http.fixtures.add({
+                        request: {
+                            method: 'GET',
+                            url: [
+                                'http://example.com',
+                                'ureporters/vumi_go_sms/+256775551122',
+                                'polls/current'
+                            ].join('/')
+                        },
+                        response: {
+                            data: {
+                                success: true,
+                                poll: null
+                            }
+                        }
+                    });
+
+                    return ureport
+                        .ureporters('+256775551122')
+                        .polls.current()
+                        .then(function(poll) {
+                            assert.strictEqual(poll, null); 
+                        });
+                });
+            });
+
             describe("if a none poll is given back", function() {
                 it("should get the next poll until the given limit is hit",
                 function() {

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -164,13 +164,29 @@ describe("app", function() {
 
         describe("when the user is on the main menu", function() {
             describe("if the user chooses to take the poll", function() {
-                it("should show the user the current poll", function() {
-                    return tester
-                        .setup.user.state('states:main_menu')
-                        .input('1')
-                        .check.reply("What is your quest?")
-                        .check.user.state('states:poll:question')
-                        .run();
+                describe("if there is a current poll", function() {
+                    it("should show the user the current poll", function() {
+                        return tester
+                            .setup.user.state('states:main_menu')
+                            .input('1')
+                            .check.reply("What is your quest?")
+                            .check.user.state('states:poll:question')
+                            .run();
+                    });
+                });
+
+                describe("if there is no current poll", function() {
+                    it("should tell the user", function() {
+                        return tester
+                            .setup.user.state('states:main_menu')
+                            .setup.user.addr('user_no_polls')
+                            .input('1')
+                            .check.reply([
+                                "There is currently no poll available,",
+                                "please try again later"].join(' '))
+                            .check.user.state('states:poll:none')
+                            .run();
+                    });
                 });
             });
 

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -43,6 +43,20 @@ module.exports = function() {
     },
     {
         "request": {
+            "url": "http://example.com/ureporters/vumi_go_test/user_no_polls"
+        },
+        "response": {
+            "data": {
+                "success": true,
+                "user": {
+                    "registered": false,
+                    "language": "en"
+                }
+            }
+        }
+    },
+    {
+        "request": {
             "url": "http://example.com/ureporters/vumi_go_test/user_on_reg_poll_1"
         },
         "response": {
@@ -488,6 +502,18 @@ module.exports = function() {
                     "type": "t",
                     "start_date": null
                 },
+                "success": true
+            },
+        }
+    },
+    {
+        "request": {
+            "method": "GET",
+            "url": "http://example.com/ureporters/vumi_go_test/user_no_polls/polls/current"
+        },
+        "response": {
+            "data": {
+                "poll": null,
                 "success": true
             },
         }


### PR DESCRIPTION
We get a `null` response if no current poll is available. We should handle this by telling the user that no polls are available at the moment.
