### PR TITLE
Handle end registration polls as EndStates

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -79,8 +79,9 @@ vumi_ureport.api = function() {
             function is_last(poll) {
                 return polls.length > opts.nones.limit
                     || !poll
+                    || opts.nones.use
                     || poll.type !== 'none'
-                    || opts.nones.use;
+                    || poll.is_registration_end;
             }
 
             function next() {

--- a/src/app.js
+++ b/src/app.js
@@ -30,6 +30,7 @@ vumi_ureport.app = function() {
                 api_config.url,
                 api_config.backend,
                 {auth: api_config.auth});
+
             self.ureporter = self.ureport.ureporters(self.user.addr);
         };
 
@@ -48,31 +49,50 @@ vumi_ureport.app = function() {
             });
         });
 
-        // TODO what to do with submission response?
-        self.states.add('states:register', function(name, opts) {
-            var error = $("Response rejected, please try again.");
-
+        self.states.add('states:register', function(name) {
             return self.ureporter.polls.current().then(function(poll) {
                 if (poll === null) {
                     return self.states.create('states:register:none');
                 }
 
-                return new FreeText(name, {
-                    question: poll.question,
+                if (poll.is_registration_end) {
+                    return self.states.create('states:register:end', {
+                        poll: poll
+                    });
+                }
 
-                    check: function(content) {
-                        return self
-                            .ureporter.poll(poll.id)
-                            .responses.submit(content)
-                            .then(function(result) {
-                                if (!result.accepted) {
-                                    return result.response || error;
-                                }
-                            });
-                    },
-
-                    next: 'states:start'
+                return self.states.create('states:register:question', {
+                    poll: poll
                 });
+            });
+        });
+
+        // TODO what to do with submission response?
+        self.states.add('states:register:question', function(name, opts) {
+            var error = $("Response rejected, please try again.");
+
+            return new FreeText(name, {
+                question: opts.poll.question,
+
+                check: function(content) {
+                    return self
+                        .ureporter.poll(opts.poll.id)
+                        .responses.submit(content)
+                        .then(function(result) {
+                            if (!result.accepted) {
+                                return result.response || error;
+                            }
+                        });
+                },
+
+                next: 'states:register'
+            });
+        });
+
+        self.states.add('states:register:end', function(name, opts) {
+            return new EndState(name, {
+                text: opts.poll.question,
+                next: 'states:start'
             });
         });
 

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -80,7 +80,7 @@ describe("api", function() {
                             success: true,
                             user: {
                                 registered: true,
-                                language: 'sw'
+                                language: 'sw',
                             }
                         }
                     }
@@ -92,7 +92,7 @@ describe("api", function() {
                     .then(function(user) {
                         assert.deepEqual(user, {
                             registered: true,
-                            language: 'sw'
+                            language: 'sw',
                         });
                     });
             });
@@ -135,7 +135,8 @@ describe("api", function() {
                             poll: {
                                 id: '1234',
                                 type: 'text',
-                                question: 'What is your name?'
+                                question: 'What is your name?',
+                                is_registration_end: false
                             }
                         }
                     }
@@ -148,7 +149,8 @@ describe("api", function() {
                         assert.deepEqual(poll, {
                             id: '1234',
                             type: 'text',
-                            question: 'What is your name?'
+                            question: 'What is your name?',
+                            is_registration_end: false
                         });
                     });
             });
@@ -170,7 +172,8 @@ describe("api", function() {
                                 poll: {
                                     id: null,
                                     type: 'none',
-                                    question: 'Hello!'
+                                    question: 'Hello!',
+                                    is_registration_end: false
                                 }
                             }
                         }, {
@@ -188,7 +191,8 @@ describe("api", function() {
                             assert.deepEqual(poll, {
                                 id: null,
                                 type: 'none',
-                                question: 'Hello!'
+                                question: 'Hello!',
+                                is_registration_end: false
                             });
                         });
                 });
@@ -239,7 +243,8 @@ describe("api", function() {
                                 poll: {
                                     id: null,
                                     type: 'none',
-                                    question: 'Hello!'
+                                    question: 'Hello!',
+                                    is_registration_end: false
                                 }
                             }
                         }, {
@@ -248,7 +253,8 @@ describe("api", function() {
                                 poll: {
                                     id: null,
                                     type: 'none',
-                                    question: 'Welcome!'
+                                    question: 'Welcome!',
+                                    is_registration_end: false
                                 }
                             }
                         }, {
@@ -257,7 +263,8 @@ describe("api", function() {
                                 poll: {
                                     id: '1234',
                                     type: 'text',
-                                    question: 'What is your name?'
+                                    question: 'What is your name?',
+                                    is_registration_end: false
                                 }
                             }
                         }]
@@ -270,7 +277,8 @@ describe("api", function() {
                             assert.deepEqual(poll, {
                                 id: '1234',
                                 type: 'text',
-                                question: 'What is your name?'
+                                question: 'What is your name?',
+                                is_registration_end: false
                             });
                         });
                 });
@@ -292,7 +300,8 @@ describe("api", function() {
                                 poll: {
                                     id: null,
                                     type: 'none',
-                                    question: 'Hello!'
+                                    question: 'Hello!',
+                                    is_registration_end: false
                                 }
                             }
                         }, {
@@ -301,7 +310,8 @@ describe("api", function() {
                                 poll: {
                                     id: '1234',
                                     type: 'text',
-                                    question: 'What is your name?'
+                                    question: 'What is your name?',
+                                    is_registration_end: false
                                 }
                             }
                         }]
@@ -314,7 +324,55 @@ describe("api", function() {
                             assert.deepEqual(poll, {
                                 id: null,
                                 type: 'none',
-                                question: 'Hello!'
+                                question: 'Hello!',
+                                is_registration_end: false
+                            });
+                        });
+                });
+
+                it("should not get the next poll if the poll ends registration",
+                function() {
+                    api.http.fixtures.add({
+                        request: {
+                            method: 'GET',
+                            url: [
+                                'http://example.com',
+                                'ureporters/vumi_go_sms/%2B256775551122',
+                                'polls/current'
+                            ].join('/')
+                        },
+                        responses: [{
+                            data: {
+                                success: true,
+                                poll: {
+                                    id: null,
+                                    type: 'none',
+                                    question: 'Congratulations!',
+                                    is_registration_end: true
+                                }
+                            }
+                        }, {
+                            data: {
+                                success: true,
+                                poll: {
+                                    id: '1234',
+                                    type: 'text',
+                                    question: 'What is your name?',
+                                    is_registration_end: false
+                                }
+                            }
+                        }]
+                    });
+
+                    return ureport
+                        .ureporters('+256775551122')
+                        .polls.current()
+                        .then(function(poll) {
+                            assert.deepEqual(poll, {
+                                id: null,
+                                type: 'none',
+                                question: 'Congratulations!',
+                                is_registration_end: true
                             });
                         });
                 });
@@ -336,7 +394,8 @@ describe("api", function() {
                                 poll: {
                                     id: null,
                                     type: 'none',
-                                    question: 'Hello!'
+                                    question: 'Hello!',
+                                    is_registration_end: false
                                 }
                             }
                         }, {
@@ -345,7 +404,8 @@ describe("api", function() {
                                 poll: {
                                     id: '1234',
                                     type: 'text',
-                                    question: 'What is your name?'
+                                    question: 'What is your name?',
+                                    is_registration_end: false
                                 }
                             }
                         }]
@@ -358,7 +418,8 @@ describe("api", function() {
                             assert.deepEqual(poll, {
                                 id: '1234',
                                 type: 'text',
-                                question: 'What is your name?'
+                                question: 'What is your name?',
+                                is_registration_end: false
                             });
                         });
                 });
@@ -380,7 +441,8 @@ describe("api", function() {
                                 poll: {
                                     id: null,
                                     type: 'none',
-                                    question: 'Hello!'
+                                    question: 'Hello!',
+                                    is_registration_end: false
                                 }
                             }
                         }, {
@@ -389,7 +451,8 @@ describe("api", function() {
                                 poll: {
                                     id: '1234',
                                     type: 'text',
-                                    question: 'What is your name?'
+                                    question: 'What is your name?',
+                                    is_registration_end: false
                                 }
                             }
                         }]
@@ -402,7 +465,8 @@ describe("api", function() {
                             assert.deepEqual(poll, {
                                 id: '1234',
                                 type: 'text',
-                                question: 'Hello! What is your name?'
+                                question: 'Hello! What is your name?',
+                                is_registration_end: false
                             });
                         });
                 });

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -45,7 +45,7 @@ describe("app", function() {
                         .setup.user({addr: 'user_not_found'})
                         .start()
                         .check.reply("How old are you?")
-                        .check.user.state('states:register')
+                        .check.user.state('states:register:question')
                         .run();
                 });
             });
@@ -56,7 +56,7 @@ describe("app", function() {
                         .setup.user({addr: 'user_not_registered'})
                         .start()
                         .check.reply("How old are you?")
-                        .check.user.state('states:register')
+                        .check.user.state('states:register:question')
                         .run();
                 });
             });
@@ -85,7 +85,7 @@ describe("app", function() {
             });
         });
 
-        describe("when the user is on a registration poll", function() {
+        describe("when the user is on a registration question poll", function() {
             it("should send the user's response to ureport", function() {
                 return tester
                     .setup.user.state('states:register')
@@ -112,24 +112,23 @@ describe("app", function() {
                             .setup.user.addr('user_on_reg_poll_1')
                             .input("21")
                             .check.reply("What is the capital of Assyria?")
-                            .check.user.state('states:register')
+                            .check.user.state('states:register:question')
                             .run();
                     });
                 });
 
-                describe("if it is the last registration poll", function() {
-                    it("should show the main menu", function() {
+                describe("if it is the last registration question poll",
+                function() {
+                    it("should show the registration end poll", function() {
                         return tester
                             .setup.user.state('states:register')
                             .setup.user.addr('user_on_reg_poll_2')
                             .input("I don't know that")
-                            .check.reply([
-                                "Ureport (Speak out for your community)",
-                                "1. This week's question",
-                                "2. Poll results",
-                                "3. Send report"
-                            ].join('\n'))
-                            .check.user.state('states:main_menu')
+                            .check.reply.properties({
+                                content: "Congratulations, you are now registered!",
+                                continue_session: false
+                            })
+                            .check.user.state('states:register:end')
                             .run();
                     });
                 });
@@ -145,7 +144,7 @@ describe("app", function() {
                             "We did not understand your response",
                             "to registration poll 1, please try again."
                         ].join(' '))
-                        .check.user.state('states:register')
+                        .check.user.state('states:register:question')
                         .run();
                 });
 
@@ -156,7 +155,7 @@ describe("app", function() {
                         .setup.user.addr('user_bad_input_on_reg_poll_2')
                         .input("bad input")
                         .check.reply("Response rejected, please try again.")
-                        .check.user.state('states:register')
+                        .check.user.state('states:register:question')
                         .run();
                 });
             });

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -114,6 +114,7 @@ module.exports = function() {
                     "language": null,
                     "question": "What is your quest?",
                     "is_registration": true,
+                    "is_registration_end": false,
                     "default_response_voice": null,
                     "type": "t",
                     "start_date": null
@@ -152,6 +153,7 @@ module.exports = function() {
                     "language": null,
                     "question": "How old are you?",
                     "is_registration": true,
+                    "is_registration_end": false,
                     "default_response_voice": null,
                     "type": "t",
                     "start_date": null
@@ -171,6 +173,7 @@ module.exports = function() {
                     "language": null,
                     "question": "What is the capital of Assyria?",
                     "is_registration": true,
+                    "is_registration_end": false,
                     "default_response_voice": null,
                     "type": "t",
                     "start_date": null
@@ -210,6 +213,7 @@ module.exports = function() {
                     "language": null,
                     "question": "How old are you?",
                     "is_registration": true,
+                    "is_registration_end": false,
                     "default_response_voice": null,
                     "type": "t",
                     "start_date": null
@@ -229,6 +233,7 @@ module.exports = function() {
                     "language": null,
                     "question": "What is the capital of Assyria?",
                     "is_registration": true,
+                    "is_registration_end": false,
                     "default_response_voice": null,
                     "type": "t",
                     "start_date": null
@@ -269,6 +274,7 @@ module.exports = function() {
                     "language": null,
                     "question": "How old are you?",
                     "is_registration": true,
+                    "is_registration_end": false,
                     "default_response_voice": null,
                     "type": "t",
                     "start_date": null
@@ -288,6 +294,7 @@ module.exports = function() {
                     "language": null,
                     "question": "What is the capital of Assyria?",
                     "is_registration": true,
+                    "is_registration_end": false,
                     "default_response_voice": null,
                     "type": "t",
                     "start_date": null
@@ -328,6 +335,7 @@ module.exports = function() {
                     "language": null,
                     "question": "How old are you?",
                     "is_registration": true,
+                    "is_registration_end": false,
                     "default_response_voice": null,
                     "type": "t",
                     "start_date": null
@@ -347,6 +355,7 @@ module.exports = function() {
                     "language": null,
                     "question": "What is the capital of Assyria?",
                     "is_registration": true,
+                    "is_registration_end": false,
                     "default_response_voice": null,
                     "type": "t",
                     "start_date": null
@@ -361,7 +370,7 @@ module.exports = function() {
             "method": "GET",
             "url": "http://example.com/ureporters/vumi_go_test/user_on_reg_poll_2/polls/current"
         },
-        "response": {
+        "responses": [{
             "data": {
                 "poll": {
                     "question_voice": null,
@@ -373,9 +382,41 @@ module.exports = function() {
                     "language": null,
                     "question": "What is the capital of Assyria?",
                     "is_registration": true,
+                    "is_registration_end": false,
                     "default_response_voice": null,
                     "type": "t",
                     "start_date": null
+                },
+                "success": true
+            },
+        }, {
+            "data": {
+                "poll": {
+                    "type": "none",
+                    "question": "Congratulations, you are now registered!",
+                    "id": null,
+                    "name": "Message",
+                    "is_registration": true,
+                    "is_registration_end": true
+                },
+                "success": true
+            },
+        }]
+    },
+    {
+        "request": {
+            "method": "GET",
+            "url": "http://example.com/ureporters/vumi_go_test/user_on_reg_end_poll/polls/current"
+        },
+        "response": {
+            "data": {
+                "poll": {
+                    "type": "none",
+                    "question": "Congratulations, you are now registered!",
+                    "id": null,
+                    "name": "Message",
+                    "is_registration": true,
+                    "is_registration_end": true
                 },
                 "success": true
             },
@@ -398,6 +439,7 @@ module.exports = function() {
                     "language": null,
                     "question": "What is the capital of Assyria?",
                     "is_registration": true,
+                    "is_registration_end": false,
                     "default_response_voice": null,
                     "type": "t",
                     "start_date": null
@@ -423,6 +465,7 @@ module.exports = function() {
                     "language": null,
                     "question": "What is your quest?",
                     "is_registration": true,
+                    "is_registration_end": false,
                     "default_response_voice": null,
                     "type": "t",
                     "start_date": null
@@ -448,6 +491,7 @@ module.exports = function() {
                     "language": null,
                     "question": "What is your quest?",
                     "is_registration": true,
+                    "is_registration_end": false,
                     "default_response_voice": null,
                     "type": "t",
                     "start_date": null
@@ -473,6 +517,7 @@ module.exports = function() {
                     "language": null,
                     "question": "What is your favourite colour?",
                     "is_registration": true,
+                    "is_registration_end": false,
                     "default_response_voice": null,
                     "type": "t",
                     "start_date": null
@@ -498,6 +543,7 @@ module.exports = function() {
                     "language": null,
                     "question": "What is your favourite colour?",
                     "is_registration": true,
+                    "is_registration_end": false,
                     "default_response_voice": null,
                     "type": "t",
                     "start_date": null


### PR DESCRIPTION
The last registration poll is in fact a 'Congratulations! ...' message instead of a question. After discussion with the U-Report team, the plan is to end the session at this message. The user will then need to dial back in to access the main menu after registration.
