### PR TITLE
EndStates don't fast forward the user anymore

### DIFF
--- a/test/app.test.js
+++ b/test/app.test.js
@@ -128,7 +128,7 @@ describe("app", function() {
                                 content: "Congratulations, you are now registered!",
                                 continue_session: false
                             })
-                            .check.user.state('states:start')
+                            .check.user.state('states:register:end')
                             .run();
                     });
                 });
@@ -183,7 +183,7 @@ describe("app", function() {
                             .check.reply([
                                 "There is currently no poll available,",
                                 "please try again later"].join(' '))
-                            .check.user.state('states:start')
+                            .check.user.state('states:poll:none')
                             .run();
                     });
                 });
@@ -215,7 +215,7 @@ describe("app", function() {
                                 "There are no polls to see results for at",
                                 "the moment, please try again later."
                             ].join(' '))
-                            .check.user.state('states:start')
+                            .check.user.state('states:results:empty')
                             .run();
                     });
                 });
@@ -227,7 +227,7 @@ describe("app", function() {
                     return tester
                         .setup.user.state('states:results:empty')
                         .start()
-                        .check.user.state('states:start')
+                        .check.user.state('states:main_menu')
                         .run();
                 });
             });
@@ -337,7 +337,7 @@ describe("app", function() {
                             "22 - 31: 2500",
                             "32 - 41: 833"
                         ].join('\n'))
-                        .check.user.state('states:start')
+                        .check.user.state('states:results:view')
                         .run();
                 });
             });
@@ -349,7 +349,7 @@ describe("app", function() {
                         .setup.user.state.creator_opts({poll_id: 'poll_1'})
                         .input('2')
                         .check.reply("Thank you for using Ureport.")
-                        .check.user.state('states:start')
+                        .check.user.state('states:end')
                         .run();
                 });
             });
@@ -367,7 +367,7 @@ describe("app", function() {
                         "22 - 31: 2500",
                         "32 - 41: 833"
                     ].join('\n'))
-                    .check.user.state('states:start')
+                    .check.user.state('states:results:view')
                     .run();
             });
         });
@@ -378,7 +378,7 @@ describe("app", function() {
                     .setup.user.state('states:results:view')
                     .setup.user.state.creator_opts({poll_id: 'poll_1'})
                     .start()
-                    .check.user.state('states:start')
+                    .check.user.state('states:main_menu')
                     .run();
             });
         });
@@ -407,7 +407,7 @@ describe("app", function() {
                         .setup.user.state('states:reports:submit')
                         .input("report text")
                         .check.reply("Thank you for your report.")
-                        .check.user.state('states:start')
+                        .check.user.state('states:reports:submit:accepted')
                         .run();
                 });
 
@@ -418,7 +418,7 @@ describe("app", function() {
                         .setup.user.state('states:reports:submit')
                         .input("report text")
                         .check.reply("Thank you for your msg.")
-                        .check.user.state('states:start')
+                        .check.user.state('states:reports:submit:accepted')
                         .run();
                 });
             });
@@ -455,7 +455,7 @@ describe("app", function() {
                 return tester
                     .setup.user.state('states:reports:submit:accepted')
                     .start()
-                    .check.user.state('states:start')
+                    .check.user.state('states:main_menu')
                     .run();
             });
         });
@@ -465,7 +465,7 @@ describe("app", function() {
                 return tester
                     .setup.user.state('states:end')
                     .start()
-                    .check.user.state('states:start')
+                    .check.user.state('states:main_menu')
                     .run();
             });
         });


### PR DESCRIPTION
Once praekelt/vumi-jssandbox-toolkit#164 lands, `EndState`s no longer fast forward the user to their next state immediately after showing content, so we need to change the tests back to how they were before #34 landed.
